### PR TITLE
improve voice leading to minimize octave jumps

### DIFF
--- a/script/analyze.py
+++ b/script/analyze.py
@@ -180,10 +180,7 @@ def annotate(progression, window, closedPosition=False):
 
     ts = get_time_signature(window)
     part.timeSignature = ts
-    if closedPosition:
-        part.append(m21.clef.TrebleClef())
-    else:
-        part.append(m21.clef.BassClef())
+    part.append(m21.clef.TrebleClef())
     # part.append(ts)
     one_beat = m21.duration.Duration(1 * ts.beatLengthToQuarterLengthRatio)
     for i in range(0, len(progression), window):
@@ -263,7 +260,7 @@ def analyze_progressions(full_progression, window):
 if __name__ == "__main__":
     s = Stream()
     for c in read_progression(
-        "output/chords.txt", "output/durations.txt", max_chords=15
+        "output/chords.txt", "output/durations.txt", max_chords=60
     ):
         s.append(c)
     analyze_progressions(s, 3)
@@ -278,5 +275,5 @@ if __name__ == "__main__":
 
     # print(f"min dist triad from major: {min_distance_from_key(3)}")
     # print(f"min dist triad from minor: {min_distance_from_key(3, mode='minor')}")
-    # annotated = annotate(s, 3, closedPosition=True)
-    # annotated.show()
+    annotated = annotate(s, 3)
+    annotated.show()

--- a/script/playback.py
+++ b/script/playback.py
@@ -50,9 +50,7 @@ if __name__ == "__main__":
     #     progression.append(n)
     # progression.show()
     # output = Stream()
-    for c in read_progression(
-        "output/chords.txt", "output/durations.txt", True, force_octave=5
-    ):
+    for c in read_progression("output/chords.txt", "output/durations.txt", True):
         symbol = m21.harmony.chordSymbolFromChord(c)
         progression.append(symbol)
         progression.append(c)

--- a/script/project_pendulum_on_tonnetz.jl
+++ b/script/project_pendulum_on_tonnetz.jl
@@ -13,7 +13,7 @@ let
     X = X[:, transient+1:end]
     t = t[transient+1:end]
 
-    tonnetz = Tonnetz()
+    tonnetz = Tonnetz(; startoctave=5)
     fig, ax = plot_pendulum_on_tonnetz(tonnetz, X, t, arrowsize=12, linewidth=2)
     save("output/pendulum_on_tonnetz.png", fig, px_per_unit=2)
     chords, durations = trajectory_to_chord_progression(tonnetz, X[1, :], X[2, :], t)

--- a/src/Tonnetz.jl
+++ b/src/Tonnetz.jl
@@ -6,23 +6,24 @@ struct Tonnetz
     notes::Matrix{Int}
 end
 
-function Tonnetz(t::TriangularLattice)
+function Tonnetz(t::TriangularLattice; startoctave::Int=3)
     notes = Matrix{Int}(undef, t.num_height, t.num_width)
-    octave = [(round(Int, (j - 1) / 3) % 3) + 3 for j in 1:t.num_height]
-    notes[:, 1] = [(7 * (j - 1)) % 12 + 12octave[j] for j in range(1, t.num_height)]
-    for i in range(2, t.num_width)
+    notes[:, 1] = 12startoctave .+ [0, 7, 2, -3, 4, -1, 6, 1, -4, 3, -2, 5]
+    notes[:, 2] = 12startoctave .+ [4, -1, 6, 1, -4, 3, -2, 5, 0, 7, 2, -3]
+    for i in 3:t.num_width
         if i % 2 == 1
-            notes[:, i] = (notes[:, i-1] .- 3 .+ 12) .% 12 + 12octave
+            notes[:, i] = notes[:, 1] .+ (((i - 1) ÷ 2) % 12)
         else
-            notes[:, i] = (notes[:, i-1] .+ 4) .% 12 + 12octave
+            notes[:, i] = notes[:, 2] .+ (((i - 1) ÷ 2) % 12)
         end
+        notes[:, i] -= 12 * ((notes[:, i] .+ 3) .÷ 12 .> startoctave)
     end
     return Tonnetz(t, notes)
 end
 
-function Tonnetz()
+function Tonnetz(; kwargs...)
     t = TriangularLattice(24, 12)
-    Tonnetz(t)
+    Tonnetz(t; kwargs...)
 end
 
 lattice(t::Tonnetz) = t.t


### PR DESCRIPTION
Reduces the maximum jump to around 1 octave, as opposed to several. Results in output centered around a given octave, plus or minus a few notes. 

I don't think that it's possible to get much smaller in terms of voice leading.